### PR TITLE
Fix LSEncoder Race Condition Crash

### DIFF
--- a/Loopstream/Z.cs
+++ b/Loopstream/Z.cs
@@ -204,7 +204,7 @@ namespace Loopstream
         }
         public void a(string text)
         {
-            System.Diagnostics.Debug.WriteLine(DateTime.UtcNow.Ticks / 10000 + " " + text);
+            // System.Diagnostics.Debug.WriteLine(DateTime.UtcNow.Ticks / 10000 + " " + text);
             lock (buf)
             {
                 if (text == buf[i].msg)


### PR DESCRIPTION
Race condition where stdinQueue was being resized during a call to stdinQueue.Dequeue() caused a null byte array to be returned, throwing a null reference exception. Switch to using ConcurrentQueue to fix this.